### PR TITLE
fix removeNonLetters

### DIFF
--- a/src/main/java/org/jqurantree/arabic/ArabicText.java
+++ b/src/main/java/org/jqurantree/arabic/ArabicText.java
@@ -390,7 +390,7 @@ public class ArabicText implements Iterable<ArabicCharacter> {
 			}
 
 			// Return text with letters.
-			text = new ArabicText(buffer, 0, characterCount);
+			text = new ArabicText(buffer, 0, letterCount);
 		}
 
 		// Return text.


### PR DESCRIPTION
Bug fix

the problem: removeNonLetters returns an ArabicText with the characterCount of the original ArabicText which is greater than the text with removed non-letters. 
It causes OutOfBoundException in the next toUnicode() call

the solutions: replace characterCount with letterCount